### PR TITLE
Add new json to csv converter controller

### DIFF
--- a/src/main/java/com/github/Uniiquee/JsonToCsvService/JsonArrayToCsvConverterController.java
+++ b/src/main/java/com/github/Uniiquee/JsonToCsvService/JsonArrayToCsvConverterController.java
@@ -1,0 +1,27 @@
+package com.github.Uniiquee.JsonToCsvService;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+import jakarta.inject.Inject;
+
+@Controller("/convertJsonToCsv")
+public class JsonArrayToCsvConverterController {
+
+    @Inject
+    JsonToCsvService jsonToCsvService;
+
+    @Post
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public HttpResponse convertJsonToCsv(@Body String jsonArray) {
+        try {
+            String csv = jsonToCsvService.convertJsonToCsv(jsonArray);
+            return HttpResponse.ok(csv);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return HttpResponse.badRequest(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/github/Uniiquee/JsonToCsvService/JsonArrayToCsvConverterControllerTest.java
+++ b/src/test/java/com/github/Uniiquee/JsonToCsvService/JsonArrayToCsvConverterControllerTest.java
@@ -1,0 +1,38 @@
+package com.github.Uniiquee.JsonToCsvService;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+public class JsonArrayToCsvConverterControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient;
+
+    @Test
+    void testOk() {
+        HttpResponse response = httpClient.toBlocking().exchange(HttpRequest.POST("/convertJsonToCsv", JsonToCsvServiceTest.JSON_ARRAY_TEST_INPUT), String.class);
+        assertEquals(HttpResponse.ok().code(),
+                response.code());
+        assertEquals(JsonToCsvServiceTest.EXPECTED_JSON_ARRAY_AS_CSV_WITHOUT_HEADER,
+                response.body());
+    }
+
+    @Test()
+    void testErrorMessage() {
+        HttpClientResponseException exception = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            httpClient.toBlocking().retrieve(HttpRequest.POST("/convertJsonToCsv","INVALID JSON"));
+        });
+        assertEquals(exception.getResponse().body(), "Unrecognized token 'INVALID': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
+                " at [Source: (String)\"INVALID JSON\"; line: 1, column: 8]");
+    }
+}


### PR DESCRIPTION
Adds an endpoint to convert json arrays to csv and tests as required by #7. Closes #7.